### PR TITLE
Bump: WATCh:0.1.6, GUARD:0.1.9

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: guard
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
-version: 0.1.5
+version: 0.1.9
 appVersion: "1.0"
 dependencies:
   - name: gateway-helm

--- a/charts/watch/Chart.yaml
+++ b/charts/watch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: watch
 description: Workload Analytics and Telemetry for Comprehensive Health (WATCH) - Observability stack for PATH and GUARD
 type: application
-version: 0.1.8
+version: 0.1.6
 appVersion: "1.0.0"
 dependencies:
   - name: kube-prometheus-stack


### PR DESCRIPTION
BUMP to publish following merge of updated chart release CI task:

-  WATCH version to 0.1.6
- GUARD version to 0.1.9
