### PR TITLE
Bump guard and watch one version

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: guard
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
-version: 0.1.9
+version: 0.1.2
 appVersion: "1.0"
 dependencies:
   - name: gateway-helm

--- a/charts/path/Chart.yaml
+++ b/charts/path/Chart.yaml
@@ -3,13 +3,13 @@ appVersion: 0.0.16
 description: A Helm chart for PATH (PATH API & Toolkit Harness)
 name: path
 type: application
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: guard
-    version: 0.1.8
+    version: 0.1.9
     repository: https://buildwithgrove.github.io/helm-charts/
   - name: watch
-    version: 0.1.5
+    version: 0.1.6
     repository: https://buildwithgrove.github.io/helm-charts/
     namespace: monitoring
     condition: observability.enabled

--- a/charts/path/Chart.yaml
+++ b/charts/path/Chart.yaml
@@ -3,13 +3,13 @@ appVersion: 0.0.16
 description: A Helm chart for PATH (PATH API & Toolkit Harness)
 name: path
 type: application
-version: 0.1.4
+version: 0.1.9
 dependencies:
   - name: guard
-    version: 0.1.9
+    version: 0.1.1
     repository: https://buildwithgrove.github.io/helm-charts/
   - name: watch
-    version: 0.1.6
+    version: 0.1.0
     repository: https://buildwithgrove.github.io/helm-charts/
     namespace: monitoring
     condition: observability.enabled

--- a/charts/watch/Chart.yaml
+++ b/charts/watch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: watch
 description: Workload Analytics and Telemetry for Comprehensive Health (WATCH) - Observability stack for PATH and GUARD
 type: application
-version: 0.1.6
+version: 0.1.1
 appVersion: "1.0.0"
 dependencies:
   - name: kube-prometheus-stack


### PR DESCRIPTION
Increment GUARD & WATCH one version from the published versions.

GUARD: `0.1.1 -> 0.1.2`
WATCH: `0.1.0 -> 0.1.1`

Reset PATH to published version: `0.1.9`

```bash
helm search repo buildwithgrove
NAME                                    CHART VERSION   APP VERSION     DESCRIPTION                                       
buildwithgrove/gcp-iam-externalsecrets  0.1.1                           A Helm chart to create a service account in you...
buildwithgrove/guard                    0.1.1           1.0             A Helm chart for deploying GUARD (Gateway Utili...
buildwithgrove/path                     0.1.9           0.0.16          A Helm chart for Kubernetes                       
buildwithgrove/universal-helm           0.1.0           1.16.0          A Universal Helm chart                            
buildwithgrove/watch                    0.1.0           1.0.0           Workload Analytics and Telemetry for Comprehens...
```