### PR TITLE
[CI] fix Helm repo add job for OCI dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,22 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
 
+      # Add repositories - skipping GUARD's OCI dependency which fails in the CI
       - name: Add repositories
         run: |
-          for dir in $(ls -d charts/*/); do
-            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          for dir in charts/*/; do
+            helm dependency list "$dir" 2>/dev/null | tail -n +2 | head -n -1 | \
+            awk '$3 !~ /^oci:\/\// { print "helm repo add " $1 " " $3 }' | \
+            while read -r cmd; do
+              echo "Executing: $cmd" && eval "$cmd"
+            done
           done
           helm repo update
+
+      # Update GUARD OCI dependency independently
+      - name: Update GUARD OCI dependency
+        run: |
+          helm dependency update charts/guard
 
       - name: Validate dependencies
         id: validate-deps


### PR DESCRIPTION
## 🌿 Summary

Fix Helm repository addition in CI to handle OCI dependencies correctly and update GUARD's OCI dependency independently.

### 🌱 Primary Changes:
- Skip adding OCI dependencies during the Helm repository addition step in CI.
- Update GUARD's OCI dependency separately to avoid CI failures.

### 🍃 Secondary changes:
- Improve script readability and robustness by using proper shell scripting practices (e.g., quoting variables, using `tail -n +2` instead of `tail +2`).
- Add logging for executed Helm commands to improve debugging.

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
