### PR TITLE
Add volume configuration from secret and conditional to create ConfigMap

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
 name: guard
 type: application
-version: 0.1.11
+version: 0.1.10
 dependencies:
   - name: gateway-helm
     version: v1.3.0

--- a/charts/guard/templates/auth-grove/pads.yaml
+++ b/charts/guard/templates/auth-grove/pads.yaml
@@ -43,11 +43,17 @@ spec:
         - containerPort: {{ $padsConfig.port }}
         volumeMounts:
           - name: {{$name}}-data
-            mountPath: {{ .Values.pads.mountPath }}
+            mountPath: {{ $padsConfig.mountPath }}
       volumes:
+      {{- if $padsConfig.fromSecret }}
+      - name: {{$name}}-data
+        secret:
+          secretName: {{ $padsConfig.fromSecret.secretName }}
+      {{- else }}
       - name: {{$name}}-data
         configMap:
           name: pads-data
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -64,10 +70,12 @@ spec:
     protocol: TCP
     name: grpc
 ---
+{{- if not $padsConfig.fromSecret }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pads-data
 data: {{- toYaml $padsConfig.configMap | nindent 4 }}
+{{- end }}
 
 {{- end }}

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -30,4 +30,7 @@ auth:
     peas:
       enabled: false
     pads:
-      enabled: false
+      enabled: true
+      mountPath: /app
+      fromSecret:
+        secretName: pads-config

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -31,6 +31,6 @@ auth:
       enabled: false
     pads:
       enabled: true
-      mountPath: /app
+      mountPath: /app/data
       fromSecret:
         secretName: pads-config


### PR DESCRIPTION
## 🌿 Summary

Adds configuration to source GUARD PADS settings from a Kubernetes Secret and enables the feature.

### 🌱 Primary Changes:
- Enable PADS by setting `enabled: true` in `values.yaml`
- Configure secret-based volume for PADS data using `fromSecret.secretName`
- Define default `mountPath` and `secretName` in `values.yaml`

### 🍃 Secondary changes:
- Refactor template to use `$padsConfig` variable for `mountPath`
- Add conditional logic to handle secret configuration in the template

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [x] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable