### PR TITLE
Add envFrom to pads deployment

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
 name: guard
 type: application
-version: 0.1.10
+version: 0.1.12
 dependencies:
   - name: gateway-helm
     version: v1.3.0

--- a/charts/guard/templates/auth-grove/pads.yaml
+++ b/charts/guard/templates/auth-grove/pads.yaml
@@ -38,7 +38,12 @@ spec:
       - name: path-auth-data-server
         image: ghcr.io/buildwithgrove/path-auth-data-server:latest
         imagePullPolicy: IfNotPresent
-        env: {{- toYaml $padsConfig.env | nindent 10 }}
+        {{- with $padsConfig.envFrom }}
+        envFrom: {{- toYaml . | nindent 10}}
+        {{- end }}
+        {{- with $padsConfig.env }}
+        env: {{- toYaml . | nindent 10}}
+        {{- end }}
         ports:
         - containerPort: {{ $padsConfig.port }}
         volumeMounts:

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -22,15 +22,18 @@ domain: ""
 services: []
 auth:
   apiKey:
-    enabled: true
+    enabled: false
     headerKey: ""
     apiKeys: []
   groveLegacy:
-    enabled: false
+    enabled: true
     peas:
       enabled: false
     pads:
       enabled: true
+      envFrom:
+        - secretRef: 
+            name: pads-db-connection
       mountPath: /app/data
       fromSecret:
         secretName: pads-config

--- a/charts/path/Chart.yaml
+++ b/charts/path/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: 0.0.16
 description: A Helm chart for PATH (PATH API & Toolkit Harness)
 name: path
 type: application
-version: 0.1.11
+version: 0.1.12
 dependencies:
   - name: guard
-    version: 0.1.11
+    version: 0.1.12
     repository: https://buildwithgrove.github.io/helm-charts/
   - name: watch
     version: 0.1.8


### PR DESCRIPTION
## 🌿 Summary

Adds `envFrom` support for PADS-GUARD configuration to include secrets and updates related component toggles and template structure.

### 🌱 Primary Changes:
- Add `envFrom` configuration to pull secrets from `pads-db-connection` in `values.yaml`
- Restructure template to handle `env` and `envFrom` separately in `auth-grove/pads.yaml`
- Enable/disable relevant components via updated flags in `values.yaml`

### 🍃 Secondary changes:
- Bump Helm chart version from `0.1.10` to `0.1.12`

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [x] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable