### PR TITLE
[Deployment] Fix GUARD chart to default to API key auth with option to override.

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
 name: guard
 type: application
-version: 0.1.13
+version: 0.1.14
 dependencies:
   - name: gateway-helm
     version: v1.3.0

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -21,16 +21,23 @@ gateway:
 domain: ""
 services: []
 auth:
+  # -- API Key auth configuration (default) --
   apiKey:
-    enabled: false
-    headerKey: ""
-    apiKeys: []
-  groveLegacy:
     enabled: true
+    headerKey: "authorization"
+    apiKeys: 
+      - test_api_key
+
+  # -- Grove Legacy auth configuration --
+  # ######### VERY IMPORTANT #########
+  # If you are not authorizing Grove Portal requests,
+  # this is VERY unlikely to fit your exact use-case.
+  groveLegacy:
+    enabled: false
     peas:
       enabled: false
     pads:
-      enabled: true
+      enabled: false
       envFrom:
         - secretRef: 
             name: pads-db-connection


### PR DESCRIPTION
## 🌿 Summary

Update GUARD Helm chart to default to API key authentication with the option to override, and bump chart version.

### 🌱 Primary Changes:
- Default authentication method changed to API key with `authorization` header and a sample `test_api_key`.
- Grove Legacy authentication is now disabled by default and marked as a specialized use-case.

### 🍃 Secondary changes:
- Bumped chart version from `0.1.13` to `0.1.14`.
- Added clear documentation comments in `values.yaml` to clarify the purpose of Grove Legacy authentication.

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
