### PR TITLE
Remove dependencies from standalone charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,6 @@ jobs:
           done
           helm repo update
 
-      - name: Validate dependencies
-        id: validate-deps
-        run: ./dependency_validation.sh
-
       - name: Create chart-releaser config
         if: success()
         run: |

--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -4,7 +4,4 @@ description: A Helm chart for development and production deployments of GUARD (G
 name: guard
 type: application
 version: 0.1.13
-dependencies:
-  - name: gateway-helm
-    version: v1.3.0
-    repository: https://buildwithgrove.github.io/helm-charts/
+

--- a/charts/path/Chart.yaml
+++ b/charts/path/Chart.yaml
@@ -4,12 +4,4 @@ description: A Helm chart for PATH (PATH API & Toolkit Harness)
 name: path
 type: application
 version: 0.1.13
-dependencies:
-  - name: guard
-    version: 0.1.13
-    repository: https://buildwithgrove.github.io/helm-charts/
-  - name: watch
-    version: 0.1.8
-    repository: https://buildwithgrove.github.io/helm-charts/
-    namespace: monitoring
-    condition: observability.enabled
+


### PR DESCRIPTION
## 🌿 Summary

Remove standalone chart dependencies and associated validation steps to simplify Helm chart configurations.

### 🌱 Primary Changes:
- Remove `gateway-helm` dependency from `guard` chart
- Remove `guard` and `watch` dependencies from `path` chart

### 🍃 Secondary changes:
- Remove dependency validation step from release workflow

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [x] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable