### PR TITLE
[GUARD] Add Reference Grant to enable cross namespace communication and ability to set namespace for GUARD resources

### DIFF
--- a/charts/guard/templates/auth-api-key/api-keys-secret.yaml
+++ b/charts/guard/templates/auth-api-key/api-keys-secret.yaml
@@ -8,6 +8,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: api-keys-secret
+  namespace: {{ $.Values.global.namespace }}
 stringData:
   # Populate the secret with the API keys from the `apiKeys` field in the
   # `auth` section of the `values.yaml` file.

--- a/charts/guard/templates/auth-api-key/security-policy.yaml
+++ b/charts/guard/templates/auth-api-key/security-policy.yaml
@@ -18,7 +18,8 @@
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: {{ $service.serviceId | lower }}-subdomain-auth-policy
+  name: {{ $service.serviceId | lower }}-subdomain-auth-policy  
+  namespace: {{ $.Values.global.namespace }}
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io

--- a/charts/guard/templates/auth-grove/pads.yaml
+++ b/charts/guard/templates/auth-grove/pads.yaml
@@ -21,6 +21,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{$name}}-pads
+  namespace: {{ $.Values.global.namespace }}
   labels:
     {{- include "guard-helm.labels" $ | nindent 4 }}
 spec:
@@ -64,6 +65,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{$name}}-pads
+  namespace: {{ $.Values.global.namespace }}
   labels:
     {{- include "guard-helm.labels" $ | nindent 4 }}
 spec:
@@ -80,6 +82,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: pads-data
+  namespace: {{ $.Values.global.namespace }}
 data: {{- toYaml $padsConfig.configMap | nindent 4 }}
 {{- end }}
 

--- a/charts/guard/templates/auth-grove/peas.yaml
+++ b/charts/guard/templates/auth-grove/peas.yaml
@@ -25,6 +25,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{$name}}-peas
+  namespace: {{ $.Values.global.namespace }}
 spec:
   replicas: {{ $peasConfig.replicas }}
   selector:
@@ -53,6 +54,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{$name}}-peas
+  namespace: {{ $.Values.global.namespace }}
 spec:
   selector:
     app: {{$name}}-peas

--- a/charts/guard/templates/auth-grove/security-policy.yaml
+++ b/charts/guard/templates/auth-grove/security-policy.yaml
@@ -21,6 +21,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
   name: {{ $service.serviceId | lower }}-subdomain-auth-policy
+  namespace: {{ $.Values.global.namespace }}
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io
@@ -40,6 +41,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
   name: {{ $service.serviceId | lower }}-header-auth-policy
+  namespace: {{ $.Values.global.namespace }}
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io
@@ -64,6 +66,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
   name: {{ $service.serviceId | lower }}-{{ $alias | lower }}-alias-header-auth-policy
+  namespace: {{ $.Values.global.namespace }}
 spec:
   targetRefs:
     - group: gateway.networking.k8s.io

--- a/charts/guard/templates/custom-envoy-proxy.yaml
+++ b/charts/guard/templates/custom-envoy-proxy.yaml
@@ -7,6 +7,7 @@ apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
   name: {{$gwname}}-custom-proxy-config
+  namespace: {{ $.Values.global.namespace }}
 spec:
   provider:
     type: Kubernetes

--- a/charts/guard/templates/envoy-gateway.yaml
+++ b/charts/guard/templates/envoy-gateway.yaml
@@ -5,6 +5,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: {{$gwname}}-envoy-gateway
+  namespace: {{ $.Values.global.namespace }}
   labels:
     {{- include "guard-helm.labels" $ | nindent 4 }}
 spec:

--- a/charts/guard/templates/routing/httproute-header.yaml
+++ b/charts/guard/templates/routing/httproute-header.yaml
@@ -61,6 +61,7 @@ spec:
   # Determine the backend service to route to.
   - backendRefs:
     - name: {{ $.Values.global.serviceName }}
+      namespace: {{ $.Values.global.namespace }}
       port: {{ $.Values.global.port }}
 
     matches:
@@ -81,7 +82,7 @@ kind: HTTPRoute
 metadata:
   # eg. F00C-eth-alias-header-route
   name: {{ $service.serviceId | lower }}-{{ . | lower }}-alias-header-route
-
+  namespace: {{ $.Values.global.namespace }}
 spec:
   parentRefs:
   - kind: Gateway
@@ -91,8 +92,8 @@ spec:
   # Determine the backend service to route to.
   - backendRefs:
     - name: {{ $.Values.global.serviceName }}
+      namespace: {{ $.Values.global.namespace }}
       port: {{ $.Values.global.port }}
-
     filters:
     # Ensure the request header "target-service-id" is set to the authoritative service ID.
     - type: RequestHeaderModifier

--- a/charts/guard/templates/routing/httproute-header.yaml
+++ b/charts/guard/templates/routing/httproute-header.yaml
@@ -50,6 +50,7 @@ kind: HTTPRoute
 metadata:
   # eg. F00C-header-route
   name: {{ $service.serviceId | lower }}-header-route
+  namespace: {{ $.Values.global.namespace }}
 
 spec:
   parentRefs:

--- a/charts/guard/templates/routing/httproute-healthz.yaml
+++ b/charts/guard/templates/routing/httproute-healthz.yaml
@@ -8,6 +8,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: healthz-route
+  namespace: {{ $.Values.global.namespace }}
 spec:
   parentRefs:
   - kind: Gateway

--- a/charts/guard/templates/routing/httproute-healthz.yaml
+++ b/charts/guard/templates/routing/httproute-healthz.yaml
@@ -18,8 +18,8 @@ spec:
         - group: ""
           kind: Service
           name: {{ $.Values.global.serviceName }}
+          namespace: {{ $.Values.global.namespace }}
           port: {{ $.Values.global.port }}
-          weight: 1
       matches:
         # /healthz route returns the health of the PATH service.
         - path:

--- a/charts/guard/templates/routing/httproute-notfound.yaml
+++ b/charts/guard/templates/routing/httproute-notfound.yaml
@@ -12,6 +12,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: resource-not-found-route
+  namespace: {{ $.Values.global.namespace }}
 spec:
   parentRefs:
   - kind: Gateway

--- a/charts/guard/templates/routing/httproute-subdomain.yaml
+++ b/charts/guard/templates/routing/httproute-subdomain.yaml
@@ -70,6 +70,7 @@ spec:
     {{- $ts := default dict .trafficSplitting }}
     - backendRefs:
         - name: {{ $.Values.global.serviceName }}
+          namespace: {{ $.Values.global.namespace }}
           port: {{ $.Values.global.port }}
           # -- CONTROLLED TRAFFIC SHIFTING --
           # If traffic splitting is enabled, set the weight for the PATH backend.
@@ -80,6 +81,7 @@ spec:
         # If traffic splitting is enabled, set a second backendRef for the Middleware backend.
         {{- if eq $ts.enabled true }}
         - name: {{ $.Values.global.middlewareServiceName }}
+          namespace: {{ $.Values.global.middlewareNamespace }}
           port: {{ $.Values.global.middlewarePort }}
           weight: {{ $ts.weights.middleware }}
         {{- end }}

--- a/charts/guard/templates/routing/httproute-subdomain.yaml
+++ b/charts/guard/templates/routing/httproute-subdomain.yaml
@@ -46,6 +46,7 @@ kind: HTTPRoute
 metadata:
   # eg. F00C-subdomain-route
   name: {{ .serviceId | lower }}-subdomain-route
+  namespace: {{ $.Values.global.namespace }}
 
 spec:
   parentRefs:

--- a/charts/guard/templates/routing/reference_grant.yaml
+++ b/charts/guard/templates/routing/reference_grant.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-middleware-reference
+  # To the Middleware Service's namespace
+  namespace: {{ $.Values.global.middlewareNamespace }}
+spec: 
+  # From the PATH namespace
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: {{ $.Values.global.namespace }}
+  # To the Middleware Service
+  to:
+  - group: ""
+    kind: Service
+    name: {{ $.Values.global.middlewareServiceName }}

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -4,8 +4,12 @@
 # See: https://github.com/buildwithgrove/helm-charts/blob/main/charts/path/values.yaml
 fullnameOverride: guard
 global:
+  namespace: path
   serviceName: path-http
   port: 3069
+  # -- CONTROLLED TRAFFIC SHIFTING --
+  # This variable must correspond to the Middleware Service's namespace.
+  middlewareNamespace: middleware
   # -- CONTROLLED TRAFFIC SHIFTING --
   # This variable must correspond to the name of the Middleware Service
   # that is deployed in the same namespace as PATH/GUARD.
@@ -15,7 +19,7 @@ global:
   # This variable must correspond to the port of the Middleware Service
   # in the same namespace as PATH/GUARD.
   # Defined in `charts/path/values.yaml`
-  middlewarePort: 3000
+  middlewarePort: 8080
 gateway:
   port: 3070
 # ** IMPORTANT: update domain value: **


### PR DESCRIPTION
## 🌿 Summary

Add `ReferenceGrant` to enable cross-namespace communication and set namespaces for GUARD resources.

### 🌱 Primary Changes:
- Added `ReferenceGrant` to allow cross-namespace communication between `HTTPRoute` and the Middleware Service.
- Updated templates to include `namespace: {{ $.Values.global.namespace }}` for consistent namespace configuration.
- Introduced `middlewareNamespace` and `middlewareServiceName` in `values.yaml` to support cross-namespace references.

### 🍃 Secondary changes:
- Updated `middlewarePort` from `3000` to `8080` in `values.yaml`.
- Ensured consistent namespace configuration across multiple GUARD resource templates.

## 🛠️ Type of change

Select one or more from the following:

- [x] New feature, functionality or library
- [x] Bug fix

## 🤯 Sanity Checklist

- [x] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
