### PR TITLE
Replace infra with annotation

### DIFF
--- a/charts/guard/templates/envoy-gateway.yaml
+++ b/charts/guard/templates/envoy-gateway.yaml
@@ -8,16 +8,10 @@ metadata:
   namespace: {{ $.Values.global.namespace }}
   labels:
     {{- include "guard-helm.labels" $ | nindent 4 }}
+  annotations:
+    gateway.envoyproxy.io/envoyproxy-name: {{$gwname}}-custom-proxy-config
 spec:
   gatewayClassName: {{$gwname}}-envoy-gateway-class
-  # Specify a custom EnvoyProxy resource to customize Envoy Gateway behavior.
-  # See the following link for more details:
-  # https://gateway.envoyproxy.io/latest/tasks/operations/customize-envoyproxy/
-  infrastructure:
-    parametersRef:
-      group: gateway.envoyproxy.io
-      kind: EnvoyProxy
-      name: {{$gwname}}-custom-proxy-config
   listeners:
     - name: http
       protocol: HTTP


### PR DESCRIPTION
1. I synched the repo using this approach: #70
2. I copy-pasted the error from [ArgoCD](https://argocd.tooling.grove.city/applications/argocd/path-gateway?view=tree&resource=health%3AHealthy&conditions=false&operation=true) (screenshot below)
		```text
		failed to create typed patch object (path/guard-envoy-gateway; gateway.networking.k8s.io/v1, Kind=Gateway): .spec.infrastructure: field not declared in schema
		```
3. Resultant claude discussion: https://claude.ai/share/13c11da0-cc7f-4f9c-916a-acaf37042e49

![Screenshot 2025-03-21 at 2 43 59 PM](https://github.com/user-attachments/assets/e8fe73ae-9b7e-438e-80b4-6ca34897739f)
