### PR TITLE
GUARD: redirect requests with no prefix to healthz endpoint

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
 name: guard
 type: application
-version: 0.1.15
+version: 0.1.16
 dependencies:
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy

--- a/charts/guard/templates/envoy-gateway.yaml
+++ b/charts/guard/templates/envoy-gateway.yaml
@@ -10,14 +10,16 @@ metadata:
     {{- include "guard-helm.labels" $ | nindent 4 }}
 spec:
   gatewayClassName: {{$gwname}}-envoy-gateway-class
+  # TODO_MVP(@adshmh): uncomment once ArgoCD version supports the `infrastructure` field in the spec.
+  #
   # Specify a custom EnvoyProxy resource to customize Envoy Gateway behavior.
   # See the following link for more details:
   # https://gateway.envoyproxy.io/latest/tasks/operations/customize-envoyproxy/
-  infrastructure:
-    parametersRef:
-      group: gateway.envoyproxy.io
-      kind: EnvoyProxy
-      name: {{$gwname}}-custom-proxy-config
+  #infrastructure:
+  #  parametersRef:
+  #    group: gateway.envoyproxy.io
+  #    kind: EnvoyProxy
+  #    name: {{$gwname}}-custom-proxy-config
   listeners:
     - name: http
       protocol: HTTP

--- a/charts/guard/templates/routing/httproute-healthz-no-prefix.yaml
+++ b/charts/guard/templates/routing/httproute-healthz-no-prefix.yaml
@@ -1,0 +1,36 @@
+# MCG performs health checks against services to which it routes traffic.
+# To remove the need for customizing MCG health checks, this HTTPRoute resource directs traffic from `/'` (MCG's default healthcheck path) to `/healthz`
+#
+# HTTPRoute Generator to direct requests with no prefix to the healthcheck endpoint.
+#
+# Generates an HTTPRoute resource for the healthz endpoint.
+#
+# Ref: https://gateway.envoyproxy.io/latest/api/gateway_api/httproute/
+{{- $gwname:= default "guard" $.Values.fullnameOverride }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: healthz-route-no-prefix
+  namespace: {{ $.Values.global.namespace }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{$gwname}}-envoy-gateway
+  rules:
+    - backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ $.Values.global.serviceName }}
+          namespace: {{ $.Values.global.namespace }}
+          port: {{ $.Values.global.port }}
+      matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /healthz


### PR DESCRIPTION
This is needed to remove the need for customizing MCG health checks.