### PR TITLE
GUARD: use v1alpha2 version in Reference Grant resource

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
 name: guard
 type: application
-version: 0.1.16
+version: 0.1.17
 dependencies:
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy

--- a/charts/guard/templates/routing/reference_grant.yaml
+++ b/charts/guard/templates/routing/reference_grant.yaml
@@ -1,4 +1,5 @@
-apiVersion: gateway.networking.k8s.io/v1beta1
+# TODO_MVP(@adshmh): Use v1beta1 as version. `v1lapha2` is used to stay compatible with the existing infra tooling.
+apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: ReferenceGrant
 metadata:
   name: allow-middleware-reference


### PR DESCRIPTION
Use `v1lapha2` version for the `ReferenceGrant` resource for compatibility with legacy infra tooling.