### PR TITLE
Add ExternalSecret resource for secret required by PADS

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
 name: guard
 type: application
-version: 0.1.17
+version: 0.1.18
 dependencies:
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy

--- a/charts/guard/templates/auth-grove/pads.yaml
+++ b/charts/guard/templates/auth-grove/pads.yaml
@@ -85,5 +85,52 @@ metadata:
   namespace: {{ $.Values.global.namespace }}
 data: {{- toYaml $padsConfig.configMap | nindent 4 }}
 {{- end }}
+---
+{{- if $padsConfig.fromSecret }}
+# ExternalSecret for PADS Postgres connection
+# # - Creates a K8s Secret from GCP Secret Manager
+# # - Includes DB connection string and SSL certificates
+# # - Secret name controlled by fromSecret.secretName
+# # - Used by PADS container for secure DB connection
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $padsConfig.fromSecret.externalSecretName | default "pads-db-connection" }}
+  namespace: {{ $.Values.global.namespace }}
+spec:
+  data:
+  - secretKey: {{ $padsConfig.fromSecret.postgresConnectionVarName | default "POSTGRES_CONNECTION_STRING" }}
+    remoteRef:
+      conversionStrategy: {{ $padsConfig.fromSecret.conversionStrategy | default "Default" }}
+      decodingStrategy: {{ $padsConfig.fromSecret.decodingStrategy | default "None" }}
+      key: {{ $padsConfig.fromSecret.keyPrefix | default "guard-pads-db-connection" }}-{{ $.Values.global.environment | default "prod" }}
+      property: POSTGRES_CONNECTION_STRING
+  - secretKey: ssl_cert.pem
+    remoteRef:
+      conversionStrategy: {{ $padsConfig.fromSecret.conversionStrategy | default "Default" }}
+      decodingStrategy: {{ $padsConfig.fromSecret.decodingStrategy | default "None" }}
+      key: {{ $padsConfig.fromSecret.keyPrefix | default "guard-pads-db-connection" }}-{{ $.Values.global.environment | default "prod" }}
+      property: ssl_cert.pem
+  - secretKey: ssl_key.pem
+    remoteRef:
+      conversionStrategy: {{ $padsConfig.fromSecret.conversionStrategy | default "Default" }}
+      decodingStrategy: {{ $padsConfig.fromSecret.decodingStrategy | default "None" }}
+      key: {{ $padsConfig.fromSecret.keyPrefix | default "guard-pads-db-connection" }}-{{ $.Values.global.environment | default "prod" }}
+      property: ssl_key.pem
+  - secretKey: ssl_root_cert.pem
+    remoteRef:
+      conversionStrategy: {{ $padsConfig.fromSecret.conversionStrategy | default "Default" }}
+      decodingStrategy: {{ $padsConfig.fromSecret.decodingStrategy | default "None" }}
+      key: {{ $padsConfig.fromSecret.keyPrefix | default "guard-pads-db-connection" }}-{{ $.Values.global.environment | default "prod" }}
+      property: ssl_root_cert.pem
+  refreshInterval: {{ $padsConfig.fromSecret.refreshInterval | default "5s" }}
+  secretStoreRef:
+    kind: SecretStore
+    name: {{ $padsConfig.fromSecret.secretStore | default "secstore-portal-gcp-secrets" }}
+  target:
+    creationPolicy: {{ $padsConfig.fromSecret.creationPolicy | default "Owner" }}
+    deletionPolicy: {{ $padsConfig.fromSecret.deletionPolicy | default "Retain" }}
+    name: {{ $padsConfig.fromSecret.secretName | default "pads-db-connection" }}
+{{- end }}
 
 {{- end }}

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -50,9 +50,14 @@ auth:
       enabled: false
     pads:
       enabled: true
-      envFrom:
-        - secretRef:
-            name: pads-db-connection
+      env:
+      # DEV_NOTE: you MUST change this if you update the `postgresConnectionVarName` field's value below.
+      - name: POSTGRES_CONNECTION_STRING # Name of the environment variable in the PADS container.
+        valueFrom:
+          secretKeyRef:
+            name: guard-pads-db-connection # Name of the Secret
+            key: POSTGRES_CONNECTION_STRING  # Key within the Secret
       mountPath: /app/data
       fromSecret:
-        secretName: pads-config
+        secretName: guard-pads-db-connection
+        postgresConnectionVarName: POSTGRES_CONNECTION_STRING  # DEV_NOTE: you MUST update the envFrom section above if you change this value.


### PR DESCRIPTION
- Move ExternalSecret creation to PADS, where the secret is needed.
- Consolidate into 1 secret with Certs and the connection string.