### PR TITLE
[LocalNet] Shannon Service IDs for LocalNet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,22 @@
 ############# Makefile helper targets ##############
 ####################################################
 
-.PHONY: list
-list: ## List all make targets
-	@${MAKE} -pRrn : -f $(MAKEFILE_LIST) 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort
-
-.PHONY: help
 .DEFAULT_GOAL := help
+
+.PHONY: list help
+
+list: ## List all make targets
+	@${MAKE} -pRrn : -f $(MAKEFILE_LIST) 2>/dev/null | \
+	  awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | \
+	  egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort
+
 help: ## Prints all make target descriptions
-	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-60s\033[0m %s\n", $$1, $$2}'
+	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	  awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-60s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT:
+	@echo "❌ Error: Target '$@' not found."
+	@exit 1
 
 ####################################################
 #############  Helm releases targets  ##############

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -10,14 +10,14 @@ global:
   serviceName: path-http
   port: 3069
 
-# Optional health check configuration
-# - Override settings for health check endpoint
-# - Defaults to global values when not specified
-# healthCheck:
-#   serviceName: path-http       # Service to target for health checks (defaults to global.serviceName)
-#   namespace: path             # Namespace for health check service (defaults to global.namespace)
-#   port: 3069                  # Port for health check service (defaults to global.port)
-#   path: "/healthz"           # Path for health checks (defaults to "/healthz")
+  # Optional health check configuration
+  # - Override settings for health check endpoint
+  # - Defaults to global values when not specified
+  # healthCheck:
+  #   serviceName: path-http       # Service to target for health checks (defaults to global.serviceName)
+  #   namespace: path             # Namespace for health check service (defaults to global.namespace)
+  #   port: 3069                  # Port for health check service (defaults to global.port)
+  #   path: "/healthz"           # Path for health checks (defaults to "/healthz")
 
   # Settings for traffic shifting
   shannonBetaNamespace: middleware
@@ -75,19 +75,19 @@ domain: "example.com"
 #   - Supports both Subdomain and Header-based routing
 # - For more information, see:
 #   - https://path.grove.city/operate/helm/guard#routing
-services:
-  # Morse-specific services
-  - serviceId: F00C
-    shannonServiceId: eth
-    aliases:
-      - eth
-      - eth-mainnet
-    # trafficSplitting:
-    #   enabled: true
-    #   weights:
-    #     path: 60
-    #     shannonBeta: 30
-    #     shannonMainnet: 20
+# services:
+# Morse-specific services
+# - serviceId: F00C
+#   shannonServiceId: eth
+#   aliases:
+#     - eth
+#     - eth-mainnet
+# trafficSplitting:
+#   enabled: true
+#   weights:
+#     path: 60
+#     shannonBeta: 30
+#     shannonMainnet: 20
 
 # GUARD auth configuration
 # Exactly one auth method must be enabled:

--- a/charts/path/values.yaml
+++ b/charts/path/values.yaml
@@ -19,10 +19,11 @@ global:
   serviceAccount:
     create: true
     name: "path-sa"
-  securityContext:
-    fsGroup: 1001
-    runAsUser: 1001
-    runAsGroup: 1001
+  # Including this in LocalNet causes issues with permissions
+  # securityContext:
+  #   fsGroup: 1001
+  #   runAsUser: 1001
+  #   runAsGroup: 1001
 
 image:
   repository: ghcr.io/buildwithgrove/path
@@ -173,6 +174,7 @@ guard:
     # Configurations:
     # - serviceId [REQUIRED]: Authoritative service ID.
     # - aliases [OPTIONAL]: Aliases for the service.
+    # TODO_TECHDEBT: The examples are outdated with respect to the serviceId format below.
     # Examples:
     #   - anvil.localhost -> target-service-id: anvil
     #   - F00C.path.grove.city -> target-service-id: F00C
@@ -180,34 +182,98 @@ guard:
     #   - polygon.path.grove.city -> target-service-id: F021
 
     # Shannon Example Service ID (with no aliases)
-    - serviceId: anvil
-
-    # Morse Example Service IDs (with aliases)
-    - serviceId: F00C
-      shannonServiceId: eth
+    - serviceId: arb-one
+      aliases:
+        - arb
+        - arb-mainnet
+    - serviceId: arb-sep-test
+    - serviceId: avax
+    - serviceId: avax-dfk
+    - serviceId: base
+    - serviceId: base-test
+    - serviceId: bera
+    - serviceId: blast
+    - serviceId: boba
+    - serviceId: bsc
+    - serviceId: celo
+    - serviceId: eth
       aliases:
         - eth
         - eth-mainnet
-      # -- CONTROLLED TRAFFIC SHIFTING --
-      # Provide configuration for splitting traffic between
-      # the PATH and Middleware backends.
-      trafficSplitting:
-        enabled: false
-        weights:
-          path: 50
-          middleware: 50
-    - serviceId: F021
+    - serviceId: eth-hol-test
+    - serviceId: eth-sep-test
+    - serviceId: evmos
+    - serviceId: fantom
+    - serviceId: fraxtal
+    - serviceId: fuse
+    - serviceId: gnosis
+    - serviceId: harmony
+    - serviceId: ink
+    - serviceId: iotex
+    - serviceId: kaia
+    - serviceId: kava
+    - serviceId: linea
+    - serviceId: mantle
+    - serviceId: metis
+    - serviceId: moonbeam
+    - serviceId: moonriver
+    - serviceId: near
+    - serviceId: oasys
+    - serviceId: op
+    - serviceId: op-sep-test
+    - serviceId: opbnb
+    - serviceId: osmosis
+    - serviceId: pocket
+    - serviceId: pocket-beta1
+    - serviceId: pocket-beta2
+    - serviceId: pocket-beta3
+    - serviceId: pocket-beta4
+    - serviceId: pocket-beta5
+    - serviceId: poly
       aliases:
-        - polygon
-        - polygon-mainnet
-      # -- CONTROLLED TRAFFIC SHIFTING --
-      # Provide configuration for splitting traffic between
-      # the PATH and Middleware backends.
-      trafficSplitting:
-        enabled: false
-        weights:
-          path: 50
-          middleware: 50
+        - poly
+        - poly-mainnet
+    - serviceId: poly-amoy-test
+    - serviceId: poly-zkevm
+    - serviceId: radix
+    - serviceId: scroll
+    - serviceId: sei
+    - serviceId: solana
+    - serviceId: sonic
+    - serviceId: sui
+    - serviceId: taiko
+    - serviceId: taiko-hek-test
+    - serviceId: tron
+    - serviceId: xrpl-evm-test
+    - serviceId: zklink-nova
+    - serviceId: zksync-era
+
+    # Morse Example Service IDs (with aliases)
+    # - serviceId: F00C
+    #   shannonServiceId: eth
+    #   aliases:
+    #     - eth
+    #     - eth-mainnet
+    #   # -- CONTROLLED TRAFFIC SHIFTING --
+    #   # Provide configuration for splitting traffic between
+    #   # the PATH and Middleware backends.
+    #   trafficSplitting:
+    #     enabled: false
+    #     weights:
+    #       path: 50
+    #       middleware: 50
+    # - serviceId: F021
+    #   aliases:
+    #     - polygon
+    #     - polygon-mainnet
+    #   # -- CONTROLLED TRAFFIC SHIFTING --
+    #   # Provide configuration for splitting traffic between
+    #   # the PATH and Middleware backends.
+    #   trafficSplitting:
+    #     enabled: false
+    #     weights:
+    #       path: 50
+    #       middleware: 50
 
   # GUARD Authorization Flows:
   # - Supported: API Key, Grove Legacy (not shown below)


### PR DESCRIPTION
The key changes are in `charts/path/values.yaml`.

In order for this to work on LocalNet with Shannon, we need to make sure the service IDs are Shannon compatible AND have aliases:

```yaml
 - serviceId: eth
      aliases:
        - eth
        - eth-mainnet
```        