### PR TITLE
[GUARD] Add PATH debug endpoints routes to GUARD

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for development and production deployments of GUARD (Gateway Utilities for Authentication, Routing & Defense)
 name: guard
 type: application
-version: 0.1.31
+version: 0.1.32
 dependencies:
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy

--- a/charts/guard/templates/auth-api-key/security-policy-debug.yaml
+++ b/charts/guard/templates/auth-api-key/security-policy-debug.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.auth.debug_endpoints }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: debug-endpoints-auth-policy
+  namespace: {{ .Values.global.namespace }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: debug-endpoints-route
+  apiKeyAuth:
+    credentialRefs:
+    - group: ""
+      kind: Secret
+      name: {{ .Values.auth.debug_endpoints.api_key_secret_name }}
+    extractFrom:
+    - headers:
+      - authorization
+{{- end }}

--- a/charts/guard/templates/routing/httproute-debug.yaml
+++ b/charts/guard/templates/routing/httproute-debug.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.auth.debug_endpoints }}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: debug-endpoints-route
+  namespace: {{ .Values.global.namespace }}
+  annotations:
+    gateway.envoyproxy.io/route-priority: "100"
+spec:
+  parentRefs:
+  {{- range .Values.gatewayRef }}
+  - group: {{ .group }}
+    kind: {{ .kind }}
+    name: {{ .name }}
+  {{- end }}
+  rules:
+  # pprof endpoints - correct service name is "path-pprof"
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /debug/pprof/
+    backendRefs:
+    - name: path-pprof
+      namespace: {{ .Values.global.namespace }}
+      port: 6060
+  # disqualified_endpoints served on port 3069 via main API service
+  - matches:
+    - path:
+        type: Exact
+        value: /disqualified_endpoints
+    backendRefs:
+    - name: {{ .Values.global.serviceName }}
+      namespace: {{ .Values.global.namespace }}
+      port: {{ .Values.global.port }}
+{{- end }}

--- a/charts/guard/templates/routing/httproute-healthz.yaml
+++ b/charts/guard/templates/routing/httproute-healthz.yaml
@@ -28,13 +28,3 @@ spec:
         - path:
             type: Exact
             value: {{ $.Values.healthCheck.path | default "/healthz" }}
-    - backendRefs:
-        - group: ""
-          kind: Service
-          name: {{ $.Values.disqualifiedEndpoints.serviceName | default $.Values.global.serviceName }}
-          namespace: {{ $.Values.disqualifiedEndpoints.namespace | default $.Values.global.namespace }}
-          port: {{ $.Values.disqualifiedEndpoints.port | default $.Values.global.port }}
-      matches:
-        - path:
-            type: Exact
-            value: {{ $.Values.disqualifiedEndpoints.path | default "/disqualified_endpoints" }}

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -13,11 +13,11 @@ global:
   # Optional health check configuration
   # - Override settings for health check endpoint
   # - Defaults to global values when not specified
-  # healthCheck:
-  #   serviceName: path-http       # Service to target for health checks (defaults to global.serviceName)
-  #   namespace: path             # Namespace for health check service (defaults to global.namespace)
-  #   port: 3069                  # Port for health check service (defaults to global.port)
-  #   path: "/healthz"           # Path for health checks (defaults to "/healthz")
+  healthCheck:
+    serviceName: path-http       # Service to target for health checks (defaults to global.serviceName)
+    namespace: path             # Namespace for health check service (defaults to global.namespace)
+    port: 3069                  # Port for health check service (defaults to global.port)
+    path: "/healthz"           # Path for health checks (defaults to "/healthz")
 
   # Settings for traffic shifting
   shannonBetaNamespace: middleware
@@ -28,6 +28,15 @@ global:
 
   shannonBetaPort: 8080
   shannonMainnetPort: 8080
+
+# Default health check configuration
+# - Can be overridden by parent chart if needed
+# - Uses global values as defaults
+healthCheck:
+  serviceName: # Will default to global.serviceName in template
+  namespace:   # Will default to global.namespace in template
+  port:        # Will default to global.port in template
+  path: "/healthz"
 
 # Optional health check configuration
 # - Override settings for health check endpoint
@@ -98,6 +107,18 @@ domain: "example.com"
 # For more information, see:
 #   - https://path.grove.city/operate/helm/guard#authentication
 auth:
+  # Debug endpoints authentication configuration
+  # - Presence of this section enables external exposure of PATH's debug endpoints via GUARD
+  # - Creates HTTPRoute and SecurityPolicy for debug endpoints with separate authentication
+  # - Covers both pprof endpoints (served on port 6060) and disqualified_endpoints (served on port 3069)
+  # - Uses API key authentication (separate from main API key auth) for security isolation
+  debug_endpoints:
+    # Kubernetes secret name containing debug API key
+    # Secret should contain 'path-debug-api-key' key with the debug API key value
+    # In local development: created by Tilt from secrets.yaml (value: "test_debug_api_key")
+    # In production: created by external secret management system
+    api_key_secret_name: "path-debug-api-keys"
+
   #
   # 1. API Key auth configuration (default)
   apiKey:

--- a/charts/watch/Chart.yaml
+++ b/charts/watch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: watch
 description: Workload Analytics and Telemetry for Comprehensive Health (WATCH) - Observability stack for PATH and GUARD
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "1.0.0"
 dependencies:
   - name: kube-prometheus-stack

--- a/charts/watch/dashboards/path/suppliers.json
+++ b/charts/watch/dashboards/path/suppliers.json
@@ -1,0 +1,871 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 15,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Percentage of requests that fall back to random endpoint selection when all endpoints fail validation, broken down by service",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(\n sum by (service_id) (rate(path_evm_requests_total{random_endpoint_fallback=\"true\"}[$__rate_interval]))\n /\n sum by (service_id) (rate(path_evm_requests_total[$__rate_interval]))\n) * 100",
+          "interval": "",
+          "legendFormat": "{{service_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fallback to Random Endpoint Selection (%) by Service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current number of valid endpoints vs available endpoints by service",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Available.*"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 20
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "path_evm_available_endpoints",
+          "interval": "",
+          "legendFormat": "{{service_id}} - Available",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "path_evm_valid_endpoints",
+          "interval": "",
+          "legendFormat": "{{service_id}} - Valid",
+          "refId": "B"
+        }
+      ],
+      "title": "Endpoint Availability by Service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Percentage of endpoint validations that succeed for each supplier (domain) per service",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "(\n sum by (service_id) (rate(path_evm_endpoint_validations_total{success=\"false\"}[$__rate_interval]))\n /\n sum by (service_id) (rate(path_evm_endpoint_validations_total[$__rate_interval]))\n) * 100",
+          "interval": "",
+          "legendFormat": "{{service_id}} - {{domain}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Supplier Endpoint Validation Failure Rate by Service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of different validation failure reasons by supplier and service over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (service_id, domain, validation_failure_reason) (increase(path_evm_endpoint_validations_total{success=\"false\", validation_failure_reason!=\"\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "{{service_id}} - {{domain}} - {{validation_failure_reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoint Validation Failure by Supplier and Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total validation attempts per supplier showing the volume of checks performed",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(path_evm_endpoint_validations_total[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "{{service_id}} - {{domain}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoint Validation Attempts by Supplier",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Top validation failure reasons across all suppliers and services",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (validation_failure_reason) (rate(path_evm_endpoint_validations_total{success=\"false\", validation_failure_reason!=\"\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "{{validation_failure_reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Validation Failure Reasons (Stacked)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Request success rate per service to correlate with supplier quality",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "vis": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(\n  rate(path_evm_requests_total{success=\"true\"}[$__rate_interval])\n  /\n  rate(path_evm_requests_total[$__rate_interval])\n) * 100",
+          "interval": "",
+          "legendFormat": "{{service_id}} - Success Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Success Rate by Service",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": [
+    "path",
+    "evm",
+    "suppliers"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "includeAll": false,
+        "label": "Data Source",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(path_evm_requests_total, service_id)",
+        "includeAll": true,
+        "label": "Service ID",
+        "multi": true,
+        "name": "service_id",
+        "options": [],
+        "query": {
+          "query": "label_values(path_evm_requests_total, service_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(path_evm_endpoint_validations_total, domain)",
+        "includeAll": true,
+        "label": "Supplier Domain",
+        "multi": true,
+        "name": "domain",
+        "options": [],
+        "query": {
+          "query": "label_values(path_evm_endpoint_validations_total, domain)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "PATH / Suppliers Overview",
+  "uid": "suppliers-overview-v1",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## SUMMARY:

Add debug endpoints routing with API key authentication on PATH: pprof and `disqualified_endpoints` can be accessed both in local development and production.

### Primary Changes:

- Create dedicated HTTPRoute for debug endpoints including /debug/pprof/ and /disqualified_endpoints paths
- Add SecurityPolicy with API key authentication for debug endpoint access protection
- Move /disqualified_endpoints routing from health check route to dedicated debug route

### Secondary Changes:

- Configure debug endpoints to be conditionally enabled via auth.debug_endpoints value
- Set high route priority (100) for debug endpoints to ensure proper matching order