### PR TITLE
Fix path values service ids

### DIFF
--- a/charts/path/Chart.yaml
+++ b/charts/path/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.0.16
 description: A Helm chart for PATH (PATH API & Toolkit Harness)
 name: path
 type: application
-version: 0.1.26
+version: 0.1.27
 dependencies:
   # TODO: Remove dependencies for internal charts.
   - name: guard

--- a/charts/path/values.yaml
+++ b/charts/path/values.yaml
@@ -244,7 +244,11 @@ guard:
     - serviceId: taiko
     - serviceId: taiko-hek-test
     - serviceId: tron
-    - serviceId: xrpl-evm-test
+    - serviceId: xrplevm
+      aliases:
+        - xrpl-evm-testnet
+        - xrpl-evm-test
+    - serviceId: xrplevm-testnet
     - serviceId: zklink-nova
     - serviceId: zksync-era
 

--- a/charts/path/values.yaml
+++ b/charts/path/values.yaml
@@ -245,10 +245,10 @@ guard:
     - serviceId: taiko-hek-test
     - serviceId: tron
     - serviceId: xrplevm
+    - serviceId: xrplevm-testnet
       aliases:
         - xrpl-evm-testnet
         - xrpl-evm-test
-    - serviceId: xrplevm-testnet
     - serviceId: zklink-nova
     - serviceId: zksync-era
 


### PR DESCRIPTION
Update PATH chart's values file: correct the service ID for `xrplevm` and `xrplevm-testnet`