### PR TITLE
[Rate Limit] Update plan free rate limit to default to monthly

### DIFF
--- a/charts/guard/Chart.yaml
+++ b/charts/guard/Chart.yaml
@@ -7,5 +7,5 @@ version: 0.1.32
 dependencies:
   - name: gateway-helm
     repository: oci://docker.io/envoyproxy
-    version: v1.4.0
+    version: v1.5.0
     condition: envoyGateway.enabled

--- a/charts/guard/docs/rate-limiting.md
+++ b/charts/guard/docs/rate-limiting.md
@@ -11,8 +11,8 @@ rateLimit:
     enabled: true
   plans:
     - header: "Rl-Plan-Free"
-      requests: 5000
-      unit: Day
+      requests: 150000
+      unit: Month
 ```
 
 To test, send a request like:
@@ -60,12 +60,12 @@ A few quick notes to get you started:
 
 | Header Value   | Requests | Unit   | Example User ID |
 | -------------- | -------- | ------ | --------------- |
-| `Rl-Plan-Free` | `5000`   | Day    | `1a2b3c4d`      |
+| `Rl-Plan-Free` | `150000` | Month  | `1a2b3c4d`      |
 | `Rl-Plan-Free` | `30`     | Second | `1a2b3c4d`      |
 | `Rl-Plan-Pro`  | `1000`   | Hour   | `5e6f7g8h`      |
 
 - Each distinct user ID in the header gets its own rate bucket.
-- Example: `Rl-Plan-Free: 1a2b3c4d` is limited to 5000/day and 30/second.
+- Example: `Rl-Plan-Free: 1a2b3c4d` is limited to 150000/month and 30/second.
 
 ### Example Rate-Limited Request
 
@@ -75,7 +75,7 @@ curl http://rpc.grove.city/v1 \
   -d '{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}'
 ```
 
-- User with `Rl-Plan-Free: 1a2b3c4d` can make 5000 requests/day.
+- User with `Rl-Plan-Free: 1a2b3c4d` can make 150000 requests/month.
 - Exceeding this will result in HTTP 429 responses.
 
 ### Rate Limit Response Headers
@@ -84,7 +84,7 @@ When a request is rate limited, Envoy includes the following headers in the resp
 
 ```
 X-Envoy-RateLimited: true
-X-RateLimit-Limit: 5000, 5000;w=86400
+X-RateLimit-Limit: 150000, 150000;w=2592000
 X-RateLimit-Remaining: 0
 X-RateLimit-Reset: 3600
 ```
@@ -96,7 +96,7 @@ These headers provide information about rate limits:
 - `X-RateLimit-Remaining`: Indicates how many requests remain in the current window
 - `X-RateLimit-Reset`: Indicates the number of seconds until the rate limit resets
 
-When multiple rate limits apply (e.g., 5000/day AND 30/second), the headers will display information for the window closest to its limit.
+When multiple rate limits apply (e.g., 150000/month AND 30/second), the headers will display information for the window closest to its limit.
 
 ### Setting Header Values
 
@@ -131,12 +131,12 @@ graph LR
 
 | Parameter                    | Description                                | Default          | Required |
 | ---------------------------- | ------------------------------------------ | ---------------- | -------- |
-| `rateLimit.enabled`          | Enable rate limiting                       | `true`           | ✅       |
-| `rateLimit.redis.enabled`    | Deploy Redis from this chart               | `true`           | ❌       |
-| `rateLimit.plans`            | Array of rate limit plans                  |                  | ✅       |
-| `rateLimit.plans[].header`   | Header for identifying rate limit subjects | `"Rl-Plan-Free"` | ✅       |
-| `rateLimit.plans[].requests` | Requests allowed per time unit             | `5000`           | ✅       |
-| `rateLimit.plans[].unit`     | Time unit (Second, Minute, Hour, Day)      | `Day`            | ✅       |
+| `rateLimit.enabled`          | Enable rate limiting                       | `true`           | ✅        |
+| `rateLimit.redis.enabled`    | Deploy Redis from this chart               | `true`           | ❌        |
+| `rateLimit.plans`            | Array of rate limit plans                  |                  | ✅        |
+| `rateLimit.plans[].header`   | Header for identifying rate limit subjects | `"Rl-Plan-Free"` | ✅        |
+| `rateLimit.plans[].requests` | Requests allowed per time unit             | `150000`         | ✅        |
+| `rateLimit.plans[].unit`     | Time unit (Second, Minute, Hour, Day)      | `Month`          | ✅        |
 
 ### Default Configuration
 
@@ -147,11 +147,11 @@ rateLimit:
     enabled: true
   plans:
     - header: "Rl-Plan-Free"
-      requests: 5000
-      unit: Day
+      requests: 150000
+      unit: Month
 ```
 
-- Limits each unique `Rl-Plan-Free` header value to 5000 requests/day.
+- Limits each unique `Rl-Plan-Free` header value to 150000 requests/month.
 
 ### Adding New Rate Limit Plans
 
@@ -161,26 +161,26 @@ rateLimit:
 ```yaml
 plans:
   - header: "Rl-Plan-Free"
-    requests: 5000
-    unit: Day
+    requests: 150000
+    unit: Month
   - header: "Rl-Plan-Pro"
     requests: 1000
     unit: Hour
 ```
 
-- `Rl-Plan-Free: XXX` → 5000/day
+- `Rl-Plan-Free: XXX` → 150000/month
 - `Rl-Plan-Pro: XXX` → 1000/hour
 
 ### Multiple Rate Limits per Plan
 
 - Add multiple entries with the same header for different units.
-- Example: Limit "free" users to 5000/day **AND** 30/second:
+- Example: Limit "free" users to 150000/month **AND** 30/second:
 
 ```yaml
 plans:
   - header: "Rl-Plan-Free"
-    requests: 5000
-    unit: Day
+    requests: 150000
+    unit: Month
   - header: "Rl-Plan-Free"
     requests: 30
     unit: Second
@@ -206,8 +206,8 @@ rateLimit:
     enabled: false
   plans:
     - header: "Rl-Plan-Free"
-      requests: 5000
-      unit: Day
+      requests: 150000
+      unit: Month
 
 gateway-helm:
   config:

--- a/charts/guard/templates/rate-limiter/ratelimit.yaml
+++ b/charts/guard/templates/rate-limiter/ratelimit.yaml
@@ -66,26 +66,14 @@ spec:
         # IMPORTANT: DO NOT CHANGE THIS TO false UNLESS YOU KNOW WHAT YOU ARE DOING
         shared: true
         limit:
-          # TODO_TECHDEBT(@commoddity):
-          #   - Envoy Gateway currently only supports rate limiting in a maximum unit of `Day`
-          #   - Divide the monthly limit by 30 as a workaround
-          #
-          # When the following Issue is solved, update as follows:
-          #   - Remove the division by 30
-          #   - Update the unit to `Month`
-          #
-          # Github references:
-          #   - Issue: https://github.com/envoyproxy/gateway/issues/6019
-          #   - Pull request: https://github.com/envoyproxy/gateway/pull/4495
-          #
-          # Daily relay limit calculation:
-          #   - (limit * 1,000,000) / 30 = <daily relay limit>
+          # Monthly relay limit calculation:
+          #   - limit * 1,000,000 = <monthly relay limit>
           #   - Examples:
-          #       - Rl-User-Limit-1: ceil(1,000,000 ÷ 30) = ceil(33,333.33...) = 33,334
-          #       - Rl-User-Limit-2: ceil(2,000,000 ÷ 30) = ceil(66,666.66...) = 66,667
-          #       - Rl-User-Limit-60: ceil(60,000,000 ÷ 30) = ceil(2,000,000) = 2,000,000
-          requests: {{ ceil (div (mul $limit 1000000) 30) }}
-          unit: Day
+          #       - Rl-User-Limit-1: 1,000,000 requests per month
+          #       - Rl-User-Limit-2: 2,000,000 requests per month
+          #       - Rl-User-Limit-60: 60,000,000 requests per month
+          requests: {{ mul $limit 1000000 }}
+          unit: Month
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/guard/values.yaml
+++ b/charts/guard/values.yaml
@@ -225,10 +225,10 @@ rateLimit:
   plans:
     # The headers set here must match the headers that are set on requests inside PEAS:
     # - https://github.com/buildwithgrove/path-external-auth-server/blob/main/ratelimit/ratelimit.go
-    # PLAN_FREE: 5000 requests per day
+    # PLAN_FREE: 150000 requests per month
     - header: "Rl-Plan-Free"
-      requests: 5000
-      unit: Day
+      requests: 150000
+      unit: Month
 
 # Envoy Gateway configuration
 # - Use this section to configure gateway-helm dependency

--- a/charts/path/docs/path-accessing-grafana.md
+++ b/charts/path/docs/path-accessing-grafana.md
@@ -86,7 +86,7 @@ If you didn't specify a custom password, retrieve it with:
 kubectl get secret path-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
 ```
 
-<!--- TODO_DOCUMENT(@HebertCL): Document how to use WATCH integrated with an already existing monitoring solution.
+<!--- TODO_DOCUMENT(@commoddity): Document how to use WATCH integrated with an already existing monitoring solution.
 -->
 ### Method 2: Kubernetes Ingress (Recommended for Production)
 

--- a/charts/path/values.yaml
+++ b/charts/path/values.yaml
@@ -93,7 +93,7 @@ path:
 # - Requires config file at /app/config/.config.yaml
 # - Choose one of the following options to provide this configuration:
 config:
-  # TODO_FUTURE(@HebertCL):
+  # TODO_FUTURE(@commoddity):
   # - Consider dropping the enabled field and using fromSecret/fromConfig fields if defined.
   #
   # Option 1: Use an existing Secret (recommended for security)

--- a/charts/watch/docs/architecture.md
+++ b/charts/watch/docs/architecture.md
@@ -186,7 +186,7 @@ graph LR
 
 :::warning TODO
 
-TODO_UPNEXT(@HebertCL): Adjust and document WATCH deployed as part of an already existing monitoring solution & deploying separate components
+TODO_UPNEXT(@commoddity): Adjust and document WATCH deployed as part of an already existing monitoring solution & deploying separate components
 
 :::
 


### PR DESCRIPTION
## 🌿 Summary

Update rate limiting configuration for free plan to use monthly limits instead of daily.

### 🌱 Primary Changes:
- Changed free plan rate limit from `5000/day` to `150000/month` in guard configuration
- Updated rate limit calculation logic to support monthly limits directly (removed workaround division by 30)
- Bumped guard chart version from `v1.4.0` to `v1.5.0`

### 🍃 Secondary changes:
- Updated documentation and examples throughout to reflect new monthly limits
- Fixed TODO owner references from `@HebertCL` to `@commoddity` in unrelated files


## 💡 New TODOs 

New TODOs introduced in this PR:
- <!--- TODO_DOCUMENT(@commoddity): Document how to use WATCH integrated with an already existing monitoring solution. - charts/path/docs/path-accessing-grafana.md
- TODO_FUTURE(@commoddity): - charts/path/values.yaml
- TODO_UPNEXT(@commoddity): Adjust and document WATCH deployed as part of an already existing monitoring solution & deploying separate components - charts/watch/docs/architecture.md

## 🛠️ Type of change

Select one or more from the following:

- [ ] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## 🤯 Sanity Checklist

- [ ] I have updated the GitHub Issue 'assignees', 'reviewers', 'labels', 'project', 'iteration' and 'milestone'
- [ ] For docs, I have run 'make docusaurus_start'
- [ ] For code, I have run 'make test_all'
- [ ] For configurations, I have update the documentation
- [ ] I added TODOs where applicable
