### PR TITLE
fix: replace hardcoded port 10001 with configurable value

### DIFF
--- a/charts/guard/templates/auth-grove/security-policy.yaml
+++ b/charts/guard/templates/auth-grove/security-policy.yaml
@@ -32,7 +32,7 @@ spec:
     grpc:
       backendRefs:
         - name: {{$name}}-peas
-          port: 10001
+          port: {{ $.Values.auth.groveLegacy.peas.port }}
 
 # Create a security policy for the header route.
 # eg. eth-header-auth-policy
@@ -52,7 +52,7 @@ spec:
     grpc:
       backendRefs:
         - name: {{$name}}-peas
-          port: 10001
+          port: {{ $.Values.auth.groveLegacy.peas.port }}
 
 {{- end }}
 


### PR DESCRIPTION
Replace hardcoded port 10001 in security-policy.yaml with {{ $.Values.auth.groveLegacy.peas.port }} to make the port configurable via helm values